### PR TITLE
output parsers of langchain

### DIFF
--- a/OutputParsers/json_output_parser.py
+++ b/OutputParsers/json_output_parser.py
@@ -1,0 +1,33 @@
+
+"""
+json parser does not enforce schema, here LLM decides the schema of output, we can get the result in json format only but not fixed schema
+"""
+
+from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
+from dotenv import load_dotenv
+from langchain_core.prompts import PromptTemplate
+from langchain_core.output_parsers import JsonOutputParser
+
+load_dotenv()
+
+# Define the model
+llm = HuggingFaceEndpoint(
+    repo_id="google/gemma-2-2b-it",
+    task="text-generation"
+)
+
+model = ChatHuggingFace(llm=llm)
+
+parser = JsonOutputParser()
+
+template = PromptTemplate(
+    template='Give me 5 facts about {topic} \n {format_instruction}',
+    input_variables=['topic'],
+    partial_variables={'format_instruction': parser.get_format_instructions()}
+)
+
+chain = template | model | parser
+
+result = chain.invoke({'topic':'black hole'})
+
+print(result)

--- a/OutputParsers/pydantic_output_parser.py
+++ b/OutputParsers/pydantic_output_parser.py
@@ -1,0 +1,38 @@
+
+"""
+structure output parser enforce schema but does not do the data validation,
+response from LL will come in the structure we define but it does nor contains the data validation
+"""
+
+
+from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
+from dotenv import load_dotenv
+from langchain_core.prompts import PromptTemplate
+from langchain_core.output_parsers import PydanticOutputParser
+from pydantic import BaseModel,Field
+
+load_dotenv()
+
+# Define the model
+llm = HuggingFaceEndpoint(
+    repo_id="google/gemma-2-2b-it",
+    task="text-generation"
+)
+
+model = ChatHuggingFace(llm=llm)
+class person(BaseModel):
+    name : str = Field(description="Name of the person")
+    age: int = Field(description="Age of the person")
+    city: str = Field(description="City name of the person belongs to")
+
+parser = PydanticOutputParser(pydantic_object=person)
+
+template = PromptTemplate(template="generate the name and age and city of a fictional {place} person\n {format_instruction}",
+               input_variables=['place'],
+               partial_variables={'format_instruction':parser.get_format_instructions()})
+
+chain = template | model| parser
+result = chain.invoke({"place":"Nepali"})
+print(result)
+
+#name='Shreya Rai' age=25 city='Kathmandu'

--- a/OutputParsers/string_output_parser.py
+++ b/OutputParsers/string_output_parser.py
@@ -1,0 +1,29 @@
+from langchain_openai import ChatOpenAI
+from dotenv import load_dotenv
+from langchain_core.prompts import PromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+load_dotenv()
+
+
+model = ChatOpenAI()
+
+# 1st prompt -> detailed report
+template1 = PromptTemplate(
+    template='Write a detailed report on {topic}',
+    input_variables=['topic']
+)
+
+# 2nd prompt -> summary
+template2 = PromptTemplate(
+    template='Write a 5 line summary on the following text. /n {text}',
+    input_variables=['text']
+)
+
+parser = StrOutputParser()
+
+chain = template1 | model | parser | template2 | model | parser
+
+result = chain.invoke({'topic':'black hole'})
+
+print(result)

--- a/OutputParsers/structured_output_parser.py
+++ b/OutputParsers/structured_output_parser.py
@@ -1,0 +1,41 @@
+
+"""
+structure output parser enforce schema but does not do the data validation,
+response from LL will come in the structure we define but it does nor contains the data validation
+"""
+
+
+from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
+from dotenv import load_dotenv
+from langchain_core.prompts import PromptTemplate
+from langchain.output_parsers import StructuredOutputParser, ResponseSchema
+
+load_dotenv()
+
+# Define the model
+llm = HuggingFaceEndpoint(
+    repo_id="google/gemma-2-2b-it",
+    task="text-generation"
+)
+
+model = ChatHuggingFace(llm=llm)
+
+schema = [
+    ResponseSchema(name='fact_1', description='Fact 1 about the topic'),
+    ResponseSchema(name='fact_2', description='Fact 2 about the topic'),
+    ResponseSchema(name='fact_3', description='Fact 3 about the topic'),
+]
+
+parser = StructuredOutputParser.from_response_schemas(schema)
+
+template = PromptTemplate(
+    template='Give 3 fact about {topic} \n {format_instruction}',
+    input_variables=['topic'],
+    partial_variables={'format_instruction':parser.get_format_instructions()}
+)
+
+chain = template | model | parser
+
+result = chain.invoke({'topic':'black hole'})
+
+print(result)


### PR DESCRIPTION
An **Output Parser** is a LangChain component that:

1. Defines how the LLM should structure its output (instructions).
2. Parses the raw LLM text into **structured Python objects** (dict, Pydantic, JSON, etc.).
3. Optionally validates the data and raises errors on invalid output.

<h1>🔹 When to Use Which Parser?</h1>

CommaSeparatedListOutputParser | Simple lists.
StructuredOutputParser                   | Fixed JSON schema (API-like).
PydanticOutputParser                      | Strong validation, Pythonic objects.
RegexParser                                    | Semi-structured raw text.
DatetimeOutputParser                     | Dates/times.
Custom Parser                                 | When none of the above fit.
